### PR TITLE
[CRITICAL] Fixed a bug in the alignment fixer

### DIFF
--- a/moderna/sequence/AlignmentMatcher.py
+++ b/moderna/sequence/AlignmentMatcher.py
@@ -42,13 +42,14 @@ class PairQueue(object):
         
     def has_more(self):
         """True as long as both queues have elements."""
-        if self.ap_queue and self.guide_queue:
+        if self.ap_queue:
             return True
         
     @property    
     def pair(self):
         """Return current pair of elements."""
-        return self.guide_queue[-1], self.ap_queue[-1]
+        guide = self.guide_queue[-1] if len(self.guide_queue) > 0 else GAP
+        return guide, self.ap_queue[-1]
     
     def next_ap(self):
         """Moves one queue forward."""

--- a/moderna/sequence/AlignmentMatcher.py
+++ b/moderna/sequence/AlignmentMatcher.py
@@ -123,6 +123,7 @@ class AlignmentMatcher(object):
             result.append((apos.target_letter, GAP))
         elif apos.has_target_gap():
             result.append((GAP, guide))
+            dqueue.next_guide()
         dqueue.next_ap()
     
     def check_matches(self, guide, apos, dqueue, result):


### PR DESCRIPTION
Hello @lenarother and @krother,

this is a fix to a critical bug discovered by a user: when the template sequence in the alignment differs from the actual sequence of the template and AlignmentMatcher attempts to fix it, it destroys gapped fragments of the alignment.

Please review and merge!

Best,
-p-